### PR TITLE
GenTableColumn中的isSuperColumn使用GenConstants中的配置内容进行比较

### DIFF
--- a/src/main/java/com/ruoyi/project/tool/gen/domain/GenTableColumn.java
+++ b/src/main/java/com/ruoyi/project/tool/gen/domain/GenTableColumn.java
@@ -1,8 +1,11 @@
 package com.ruoyi.project.tool.gen.domain;
 
 import javax.validation.constraints.NotBlank;
+
+import com.ruoyi.common.constant.GenConstants;
 import com.ruoyi.common.utils.StringUtils;
 import com.ruoyi.framework.web.domain.BaseEntity;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * 代码生成业务字段表 gen_table_column
@@ -331,10 +334,7 @@ public class GenTableColumn extends BaseEntity
     public static boolean isSuperColumn(String javaField)
     {
         return StringUtils.equalsAnyIgnoreCase(javaField,
-                // BaseEntity
-                "createBy", "createTime", "updateBy", "updateTime", "remark",
-                // TreeEntity
-                "parentName", "parentId", "orderNum", "ancestors");
+                ArrayUtils.addAll(GenConstants.TREE_ENTITY, GenConstants.BASE_ENTITY));
     }
 
     public boolean isUsableColumn()


### PR DESCRIPTION
22年2月16日的版本中，GenTableColumn这里使用了悬空的字符串，而GenConstants中已有配置，参考GenTable中的改写了一下。